### PR TITLE
Simplify config path and increase portability

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -25,7 +25,7 @@ log.info('App starting...')
 const connectionManager = new ConnectionManager()
 connectionManager.manageConnections()
 
-const configStorage = new ConfigStorage(path.join(app.getPath('appData'), app.name, 'settings.json'))
+const configStorage = new ConfigStorage(path.join(app.getPath('userData'), 'settings.json'))
 configStorage.init()
 
 // Keep a global reference of the window object, if you don't, the window will


### PR DESCRIPTION
https://www.electronjs.org/docs/api/app#appgetpathname

The `userData` directory is equivalent to `appData` + `app.name`.
However, it can be overridden with the command line option `--user-data-dir`, this means users can change the location of where the electron browser data and config data are stored.
e.g. `"MQTT Explorer.exe" --user-data-dir=".../data"`.
