### PR TITLE
Accept smaller key files

### DIFF
--- a/app/src/actions/ConnectionManager.ts
+++ b/app/src/actions/ConnectionManager.ts
@@ -83,7 +83,7 @@ async function openCertificate(): Promise<CertificateParameters> {
   }
 
   const data = await fsPromise.readFile(selectedFile)
-  if (data.length > 16_384 || data.length < 128) {
+  if (data.length > 16_384 || data.length < 64) {
     throw rejectReasons.certificateSizeDoesNotMatch
   }
 


### PR DESCRIPTION
I can generate a valid key file for my Mosquitto setup that fails the minimum size check of 128, for example this kind of key:

-----BEGIN PRIVATE KEY-----
MC4CAQAwBQYDK2VwBCIEIFXWXY9yVJRKhZRfLz/oaAcjmOzX/2El+QRU+/1Npyfe
-----END PRIVATE KEY-----