### PR TITLE
Allow for "+" wildcard in search expression

### DIFF
--- a/app/src/actions/Settings.ts
+++ b/app/src/actions/Settings.ts
@@ -102,13 +102,13 @@ export const filterTopics = (filterStr: string) => (dispatch: Dispatch<any>, get
     return
   }
 
-  const topicFilter = filterStr.toLowerCase()
+  const topicFilter = filterStr
   // code heavily inspired by https://stackoverflow.com/a/32402438
   const escapeRegex = (str: string) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
   const reTopicFilter = new RegExp(topicFilter.split('+').map(escapeRegex).join('[^/]+'))
 
   const nodeFilter = (node: q.TreeNode<TopicViewModel>): boolean => {
-    const topicMatches = node.path().toLowerCase().search(reTopicFilter) !== -1
+    const topicMatches = node.path().search(reTopicFilter) !== -1
     if (topicMatches) {
       return true
     }
@@ -126,7 +126,8 @@ export const filterTopics = (filterStr: string) => (dispatch: Dispatch<any>, get
     .filter(nodeFilter)
     .map((node: q.TreeNode<TopicViewModel>) => {
       const clone = node.unconnectedClone()
-      q.TreeNodeFactory.insertNodeAtPosition(node.path().split('/'), clone)
+      const edgeNames = node.path().replace(reTopicFilter, filterStr).split('/')
+      q.TreeNodeFactory.insertNodeAtPosition(edgeNames, clone)
       return clone.firstNode()
     })
     .reduce((a: q.TreeNode<TopicViewModel>, b: q.TreeNode<TopicViewModel>) => {

--- a/app/src/actions/Settings.ts
+++ b/app/src/actions/Settings.ts
@@ -103,9 +103,12 @@ export const filterTopics = (filterStr: string) => (dispatch: Dispatch<any>, get
   }
 
   const topicFilter = filterStr.toLowerCase()
+  // code heavily inspired by https://stackoverflow.com/a/32402438
+  const escapeRegex = (str: string) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+  const reTopicFilter = new RegExp(topicFilter.split('+').map(escapeRegex).join('[^/]+'))
 
   const nodeFilter = (node: q.TreeNode<TopicViewModel>): boolean => {
-    const topicMatches = node.path().toLowerCase().indexOf(topicFilter) !== -1
+    const topicMatches = node.path().toLowerCase().search(reTopicFilter) !== -1
     if (topicMatches) {
       return true
     }


### PR DESCRIPTION
Dear Thomas

Many thanks for your great MQTT-Explorer! I added support for the "+" wildcard in search expressions.
Moreover, if the search expression contains a "+" wildcard the corresponding topic levels are grouped under a single node (re-)named to "+". For example, if there are messages available under the following topics:
* a/GUID-1/x/y
* a/GUID-1/u/v
* a/GUID-2/u/w
and the search expression is "a/+/" the displayed tree becomes
a ¬
    + ¬
         x ¬
         |   y
         u ¬
             v
             w.
 Would love to see this feature merged into a future release. Parts of it might also contribute to issue #69.

Greets Georg

P.S. By the way, what are your plans for this project? Any chances you return? Any chances you release it under a more community friendly license?