### PR TITLE
Add support for Pre-Shared-Key (PSK-TLS) connections

### DIFF
--- a/app/src/actions/ConnectionManager.ts
+++ b/app/src/actions/ConnectionManager.ts
@@ -50,7 +50,19 @@ export const loadConnectionSettings = () => async (dispatch: Dispatch<any>, getS
   }
 }
 
-export type CertificateTypes = 'selfSignedCertificate' | 'clientCertificate' | 'clientKey'
+// A Pre-shared-key is a symmetric encryption key, such as an AES-128 key, that is shared
+// ahead of time (out of band) between the client and server. It might be programmed into
+// the firmware at the factory for an IoT device.
+//
+// The server optionally sends a `psk_hint`, and the client sends a `pskIdentity` (also
+// sometimes called an hint) that functions as a username. The server uses the `pskIdentity`
+// to figure out which shared key to use, and they both encrypt using that key.
+//
+// For more information on the `psk` and `pskIdentity` options:
+// See https://mosquitto.org/man/mosquitto-conf-5.html#idm854 "Pre-shared-key based SSL/TLS Support", and also
+// mosquitto's `psk_file` option.
+
+export type CertificateTypes = 'selfSignedCertificate' | 'clientCertificate' | 'clientKey' | 'psk'
 export const selectCertificate =
   (type: CertificateTypes, connectionId: string) => async (dispatch: Dispatch<any>, getState: () => AppState) => {
     try {

--- a/app/src/components/ConnectionSetup/Certificates.tsx
+++ b/app/src/components/ConnectionSetup/Certificates.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import CertificateFileSelection from './CertificateFileSelection'
 import Undo from '@material-ui/icons/Undo'
 import { bindActionCreators } from 'redux'
-import { Button, Grid } from '@material-ui/core'
+import { Button, Grid, TextField } from '@material-ui/core'
 import { connect } from 'react-redux'
 import { connectionManagerActions } from '../../actions'
 import { ConnectionOptions } from '../../model/ConnectionOptions'
@@ -66,6 +66,16 @@ class Certificates extends React.PureComponent<Props, State> {
                 certificate={this.props.connection.clientKey}
                 title="Client Key"
                 certificateType="clientKey"
+              />
+            </Grid>
+            <Grid item={true} xs={12} className={classes.gridPadding}>
+              <TextField
+                className={`${classes.fullWidth} advanced-connection-settings-topic-input`}
+                label="Pre Shared Key (PSK)"
+                placeholder="0123456789ABCDEF0123456789ABCDEF"
+                margin="normal"
+                value={this.props.connection.psk}
+                onChange={this.handleChange('psk')}
               />
             </Grid>
             <Grid item={true} xs={2} className={classes.gridPadding}>

--- a/app/src/model/ConnectionOptions.ts
+++ b/app/src/model/ConnectionOptions.ts
@@ -26,6 +26,7 @@ export interface ConnectionOptions {
   clientCertificate?: CertificateParameters
   clientKey?: CertificateParameters
   clientId?: string
+  psk?: string
   subscriptions: Array<Subscription>
 }
 
@@ -45,6 +46,7 @@ export function toMqttConnection(options: ConnectionOptions): MqttOptions | unde
     certificateAuthority: options.selfSignedCertificate ? options.selfSignedCertificate.data : undefined,
     clientCertificate: options.clientCertificate ? options.clientCertificate.data : undefined,
     clientKey: options.clientKey ? options.clientKey.data : undefined,
+    psk: options.psk ? options.psk : undefined,
   }
 }
 


### PR DESCRIPTION
- Option added to Certificates dialog even though it's not really a cert
  - Seemed like the best / most "TLS advanced option" place After all, it's used INSTEAD of a cert
- Uses the username as the identity
  - a future advancement might add a pskIdentity field, since technically it doesn't have to be the same
- Requires unchecking Verify TLS
  - There's no cert to verify when using PSK