### PR TITLE
feat: support save and load payload from file

### DIFF
--- a/app/src/actions/ConnectionManager.ts
+++ b/app/src/actions/ConnectionManager.ts
@@ -9,12 +9,11 @@ import {
 import { default as persistentStorage, StorageIdentifier } from '../utils/PersistentStorage'
 import { Dispatch } from 'redux'
 import { showError } from './Global'
-import { promises as fsPromise } from 'fs'
 import * as path from 'path'
 import { ActionTypes, Action } from '../reducers/ConnectionManager'
 import { Subscription } from '../../../backend/src/DataSource/MqttSource'
 import { connectionsMigrator } from './migrations/Connection'
-import { rendererRpc } from '../../../events'
+import { rendererRpc, readFromFile } from '../../../events'
 import { makeOpenDialogRpc } from '../../../events/OpenDialogRequest'
 
 export interface ConnectionDictionary {
@@ -81,7 +80,7 @@ async function openCertificate(): Promise<CertificateParameters> {
     throw rejectReasons.noCertificateSelected
   }
 
-  const data = await fsPromise.readFile(selectedFile)
+  const data = await rendererRpc.call(readFromFile, { filePath: selectedFile })
   if (data.length > 16_384 || data.length < 64) {
     throw rejectReasons.certificateSizeDoesNotMatch
   }

--- a/app/src/actions/Publish.ts
+++ b/app/src/actions/Publish.ts
@@ -17,31 +17,36 @@ export const setTopic = (topic?: string): Action => {
 export const openFile = () => async (dispatch: Dispatch<any>, getState: () => AppState) => {
   try {
     const file = await getFileContent()
-    dispatch(
-      setPayload(Base64Message.fromBuffer(file.data).toUnicodeString()
-      ))
+    if (file) {
+      dispatch(
+        setPayload(Base64Message.fromBuffer(file.data).toUnicodeString()
+        ))
+    }
   } catch (error) {
     dispatch(showError(error))
   }
-
 }
 
 type FileParameters = {
   name: string,
   data: Buffer
 }
-async function getFileContent(): Promise<FileParameters> {
+async function getFileContent(): Promise<FileParameters | undefined> {
   const rejectReasons = {
     noFileSelected: 'No file selected',
     errorReadingFile: 'Error reading file'
   }
 
-  const openDialogReturnValue = await rendererRpc.call(makeOpenDialogRpc(), {
+  const { canceled, filePaths } = await rendererRpc.call(makeOpenDialogRpc(), {
     properties: ['openFile'],
     securityScopedBookmarks: true,
   })
 
-  const selectedFile = openDialogReturnValue.filePaths && openDialogReturnValue.filePaths[0]
+  if (canceled) {
+    return
+  }
+
+  const selectedFile = filePaths[0]
   if (!selectedFile) {
     throw rejectReasons.noFileSelected
   }

--- a/app/src/components/Sidebar/Publish/Publish.tsx
+++ b/app/src/components/Sidebar/Publish/Publish.tsx
@@ -1,5 +1,5 @@
 import Editor from './Editor'
-import FormatAlignLeft from '@material-ui/icons/FormatAlignLeft'
+import { AttachFileOutlined, FormatAlignLeft } from '@material-ui/icons'
 import Message from './Model/Message'
 import Navigation from '@material-ui/icons/Navigation'
 import PublishHistory from './PublishHistory'
@@ -116,6 +116,10 @@ const EditorMode = memo(function EditorMode(props: {
     props.actions.setEditorMode(value)
   }, [])
 
+  const openFile = useCallback(() => {
+    props.actions.openFile()
+  }, [])
+
   const formatJson = useCallback(() => {
     if (props.payload) {
       try {
@@ -132,6 +136,7 @@ const EditorMode = memo(function EditorMode(props: {
       <div style={{ width: '100%', lineHeight: '64px', textAlign: 'center' }}>
         <EditorModeSelect value={props.editorMode} onChange={updateMode} focusEditor={props.focusEditor} />
         <FormatJsonButton editorMode={props.editorMode} focusEditor={props.focusEditor} formatJson={formatJson} />
+        <OpenFileButton editorMode={props.editorMode} openFile={openFile} />
         <div style={{ float: 'right' }}>
           <PublishButton publish={props.publish} focusEditor={props.focusEditor} />
         </div>
@@ -158,6 +163,20 @@ const FormatJsonButton = React.memo(function FormatJsonButton(props: {
         id="sidebar-publish-format-json"
       >
         <FormatAlignLeft style={{ fontSize: '20px' }} />
+      </Fab>
+    </Tooltip>
+  )
+})
+
+const OpenFileButton = React.memo(function OpenFileButton(props: { editorMode: string; openFile: () => void }) {
+  return (
+    <Tooltip title="Open file">
+      <Fab
+        style={{ width: '36px', height: '36px', margin: '0 8px' }}
+        onClick={props.openFile}
+        id="sidebar-publish-open-file"
+      >
+        <AttachFileOutlined style={{ fontSize: '20px' }} />
       </Fab>
     </Tooltip>
   )

--- a/app/src/components/Sidebar/ValueRenderer/ValuePanel.tsx
+++ b/app/src/components/Sidebar/ValueRenderer/ValuePanel.tsx
@@ -1,6 +1,7 @@
 import * as q from '../../../../../backend/src/Model'
 import ActionButtons from './ActionButtons'
 import Copy from '../../helper/Copy'
+import Save from '../../helper/Save'
 import DateFormatter from '../../helper/DateFormatter'
 import MessageHistory from './MessageHistory'
 import Panel from '../Panel'
@@ -59,6 +60,12 @@ function ValuePanel(props: Props) {
     return node?.message && decodeMessage(node.message)?.message?.toUnicodeString()
   }, [node, decodeMessage])
 
+  const getBuffer = () => {
+    if (node?.message && node.message.payload) {
+      return node.message.payload.toBuffer()
+    }
+  }
+
   function messageMetaInfo() {
     if (!props.node || !props.node.message) {
       return null
@@ -93,10 +100,13 @@ function ValuePanel(props: Props) {
   const [value] =
     node && node.message && node.message.payload ? node.message.payload?.format(node.type) : [null, undefined]
   const copyValue = value ? <Copy getValue={getDecodedValue} /> : null
+  const saveValue = value ? <Save getBuffer={getBuffer} /> : null
 
   return (
     <Panel>
-      <span>Value {copyValue}</span>
+      <span>
+        Value {copyValue} {saveValue}
+      </span>
       <span style={{ width: '100%' }}>
         {renderViewOptions()}
         <div style={{ marginBottom: '-8px', marginTop: '8px' }}>

--- a/app/src/components/Sidebar/ValueRenderer/ValuePanel.tsx
+++ b/app/src/components/Sidebar/ValueRenderer/ValuePanel.tsx
@@ -60,9 +60,9 @@ function ValuePanel(props: Props) {
     return node?.message && decodeMessage(node.message)?.message?.toUnicodeString()
   }, [node, decodeMessage])
 
-  const getBuffer = () => {
+  const getData = () => {
     if (node?.message && node.message.payload) {
-      return node.message.payload.toBuffer()
+      return node.message.payload.base64Message
     }
   }
 
@@ -100,7 +100,7 @@ function ValuePanel(props: Props) {
   const [value] =
     node && node.message && node.message.payload ? node.message.payload?.format(node.type) : [null, undefined]
   const copyValue = value ? <Copy getValue={getDecodedValue} /> : null
-  const saveValue = value ? <Save getBuffer={getBuffer} /> : null
+  const saveValue = value ? <Save getData={getData} /> : null
 
   return (
     <Panel>

--- a/app/src/components/helper/Save.tsx
+++ b/app/src/components/helper/Save.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import { connect } from 'react-redux'
+import Check from '@material-ui/icons/Check'
+import CustomIconButton from './CustomIconButton'
+import { promises as fsPromise } from 'fs'
+import { SaveAlt } from '@material-ui/icons'
+import { bindActionCreators } from 'redux'
+import { rendererRpc } from '../../../../events'
+import { makeSaveDialogRpc } from '../../../../events/OpenDialogRequest'
+
+import { globalActions } from '../../actions'
+
+export async function saveToFile(buffer: Buffer | string): Promise<string | undefined> {
+  const rejectReasons = {
+    errorWritingFile: 'Error writing file',
+  }
+
+  const { canceled, filePath } = await rendererRpc.call(makeSaveDialogRpc(), {
+    securityScopedBookmarks: true,
+  })
+
+  if (!canceled && filePath !== undefined) {
+    try {
+      await fsPromise.writeFile(filePath, buffer)
+      return filePath
+    } catch (error) {
+      throw rejectReasons.errorWritingFile
+    }
+  }
+}
+
+interface Props {
+  getBuffer: () => Buffer | undefined
+  actions: {
+    global: typeof globalActions
+  }
+}
+
+interface State {
+  didSave: boolean
+}
+
+class Save extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { didSave: false }
+  }
+
+  private handleClick = async (event: React.MouseEvent) => {
+    event.stopPropagation()
+    const buffer = this.props.getBuffer()
+    if (buffer !== undefined) {
+      const filename = await saveToFile(buffer)
+      this.props.actions.global.showNotification(`Saved to ${filename}`)
+      this.setState({ didSave: true })
+      setTimeout(() => {
+        this.setState({ didSave: false })
+      }, 1500)
+    }
+  }
+
+  public render() {
+    const icon = !this.state.didSave ? (
+      <SaveAlt fontSize="inherit" />
+    ) : (
+      <Check fontSize="inherit" style={{ cursor: 'default' }} />
+    )
+
+    return (
+      <CustomIconButton onClick={this.handleClick} tooltip="Save to file">
+        <div style={{ marginTop: '2px' }}>{icon}</div>
+      </CustomIconButton>
+    )
+  }
+}
+
+const mapDispatchToProps = (dispatch: any) => {
+  return {
+    actions: {
+      global: bindActionCreators(globalActions, dispatch),
+    },
+  }
+}
+
+export default connect(undefined, mapDispatchToProps)(Save)

--- a/app/src/components/helper/Save.tsx
+++ b/app/src/components/helper/Save.tsx
@@ -5,7 +5,7 @@ import CustomIconButton from './CustomIconButton'
 
 import { SaveAlt } from '@material-ui/icons'
 import { bindActionCreators } from 'redux'
-import { rendererRpc, writeFile } from '../../../../events'
+import { rendererRpc, writeToFile } from '../../../../events'
 import { makeSaveDialogRpc } from '../../../../events/OpenDialogRequest'
 
 import { globalActions } from '../../actions'
@@ -21,7 +21,7 @@ export async function saveToFile(data: string): Promise<string | undefined> {
 
   if (!canceled && filePath !== undefined) {
     try {
-      const filename = await rendererRpc.call(writeFile, { filePath, data })
+      const filename = await rendererRpc.call(writeToFile, { filePath, data })
       return filePath
     } catch (error) {
       throw rejectReasons.errorWritingFile

--- a/events/Events.ts
+++ b/events/Events.ts
@@ -54,3 +54,7 @@ export function makeConnectionMessageEvent(connectionId: string): Event<MqttMess
 export const getAppVersion: RpcEvent<void, string> = {
   topic: 'getAppVersion',
 }
+
+export const writeFile: RpcEvent<{ filePath: string, data: string }, void> = {
+  topic: 'writeFile',
+}

--- a/events/Events.ts
+++ b/events/Events.ts
@@ -55,6 +55,10 @@ export const getAppVersion: RpcEvent<void, string> = {
   topic: 'getAppVersion',
 }
 
-export const writeFile: RpcEvent<{ filePath: string, data: string }, void> = {
+export const writeToFile: RpcEvent<{ filePath: string, data: string, encoding?: string }, void> = {
   topic: 'writeFile',
+}
+
+export const readFromFile: RpcEvent<{ filePath: string, encoding?: string }, Buffer> = {
+  topic: 'readFromFile',
 }

--- a/events/OpenDialogRequest.ts
+++ b/events/OpenDialogRequest.ts
@@ -1,8 +1,14 @@
-import { OpenDialogOptions, OpenDialogReturnValue } from 'electron'
+import { OpenDialogOptions, OpenDialogReturnValue, SaveDialogOptions, SaveDialogReturnValue } from 'electron'
 import { RpcEvent } from './EventSystem/Rpc'
 
 export function makeOpenDialogRpc(): RpcEvent<OpenDialogOptions, OpenDialogReturnValue> {
   return {
     topic: 'openDialog',
+  }
+}
+
+export function makeSaveDialogRpc(): RpcEvent<SaveDialogOptions, SaveDialogReturnValue> {
+  return {
+    topic: 'saveDialog',
   }
 }

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -12,7 +12,7 @@ import { waitForDevServer, isDev, runningUiTestOnCi, loadDevTools } from './deve
 import { shouldAutoUpdate, handleAutoUpdate } from './autoUpdater'
 import { registerCrashReporter } from './registerCrashReporter'
 import { makeOpenDialogRpc, makeSaveDialogRpc } from '../events/OpenDialogRequest'
-import { backendRpc, getAppVersion, writeFile } from '../events'
+import { backendRpc, getAppVersion, writeToFile, readFromFile } from '../events'
 
 registerCrashReporter()
 
@@ -33,8 +33,12 @@ app.whenReady().then(() => {
 
   backendRpc.on(getAppVersion, async () => app.getVersion())
 
-  backendRpc.on(writeFile, async ({ filePath, data }) => {
-    await fsPromise.writeFile(filePath, Buffer.from(data, 'base64'))
+  backendRpc.on(writeToFile, async ({ filePath, data, encoding }) => {
+    await fsPromise.writeFile(filePath, Buffer.from(data, 'base64'), { encoding })
+  })
+
+  backendRpc.on(readFromFile, async ({ filePath, encoding }) => {
+    return fsPromise.readFile(filePath, { encoding })
   })
 })
 

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -10,7 +10,7 @@ import buildOptions from './buildOptions'
 import { waitForDevServer, isDev, runningUiTestOnCi, loadDevTools } from './development'
 import { shouldAutoUpdate, handleAutoUpdate } from './autoUpdater'
 import { registerCrashReporter } from './registerCrashReporter'
-import { makeOpenDialogRpc } from '../events/OpenDialogRequest'
+import { makeOpenDialogRpc, makeSaveDialogRpc } from '../events/OpenDialogRequest'
 import { backendRpc, getAppVersion } from '../events'
 
 registerCrashReporter()
@@ -25,6 +25,11 @@ app.whenReady().then(() => {
   backendRpc.on(makeOpenDialogRpc(), async request => {
     return dialog.showOpenDialog(BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0], request)
   })
+
+  backendRpc.on(makeSaveDialogRpc(), async request => {
+    return dialog.showSaveDialog(BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0], request)
+  })
+
   backendRpc.on(getAppVersion, async () => app.getVersion())
 })
 

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -4,6 +4,7 @@ import ConfigStorage from '../backend/src/ConfigStorage'
 import { app, BrowserWindow, Menu, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { ConnectionManager } from '../backend/src/index'
+import { promises as fsPromise } from 'fs'
 // import { electronTelemetryFactory } from 'electron-telemetry'
 import { menuTemplate } from './MenuTemplate'
 import buildOptions from './buildOptions'
@@ -11,7 +12,7 @@ import { waitForDevServer, isDev, runningUiTestOnCi, loadDevTools } from './deve
 import { shouldAutoUpdate, handleAutoUpdate } from './autoUpdater'
 import { registerCrashReporter } from './registerCrashReporter'
 import { makeOpenDialogRpc, makeSaveDialogRpc } from '../events/OpenDialogRequest'
-import { backendRpc, getAppVersion } from '../events'
+import { backendRpc, getAppVersion, writeFile } from '../events'
 
 registerCrashReporter()
 
@@ -31,6 +32,10 @@ app.whenReady().then(() => {
   })
 
   backendRpc.on(getAppVersion, async () => app.getVersion())
+
+  backendRpc.on(writeFile, async ({ filePath, data }) => {
+    await fsPromise.writeFile(filePath, Buffer.from(data, 'base64'))
+  })
 })
 
 autoUpdater.logger = log


### PR DESCRIPTION
## Features

### Save / Load payload from file
- [x] Open file dialog to set topic payload from file when publishing
- [x] Save value from payload to file 
- [x] Use cases 
  - [x] for convenience
  - [ ] saving binary files is not supported, files are generated with utf8 encoding
 
### Certificate selection
 - [x] Move file operation to backend (not tested!)
 
## Publish from file
![image](https://github.com/thomasnordquist/MQTT-Explorer/assets/10961167/9a12489b-d155-4ab1-95ab-a29a630946b8)

![image](https://github.com/thomasnordquist/MQTT-Explorer/assets/10961167/01ab275a-be50-483e-ab3d-ba7e79028258)


## Save payload to file

![image](https://github.com/thomasnordquist/MQTT-Explorer/assets/10961167/dca36947-84b5-4467-b0ba-de4127546715)
