### PR TITLE
Chore/fix workflow sha

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: '${{ github.event.pull_request.merge_commit_sha }}' # since event is pull_request_target
       - name: Install Packages
         run: yarn install --frozen-lockfile
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Show URL
         run: echo '${{ steps.upload.outputs.file-url }}'
         id: artifact-upload-step
-      - run: echo '![test](${{ steps.upload.outputs.file-url }})' >> $GITHUB_STEP_SUMMARY
+      - run: echo '<picture><img src="${{ steps.upload.outputs.file-url }}"></picture>' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
fixes #806 

- [x] checkout merge commit of PR
  - `pull_request_target` event default ref is `base branch` latest commit
- [x] fix broken test results image. Image is too big to be embedded in markdown.
  - use `<picture>` tag to link to source

@thomasnordquist I believe this is the cause of weird test results. Also I think changes above in `test.yml` need to be merged to master before changes take effect.