### PR TITLE
fix(app): migrate ChartPanel grid item to the MUI v7 Grid API

### DIFF
--- a/app/src/components/ChartPanel/index.tsx
+++ b/app/src/components/ChartPanel/index.tsx
@@ -95,7 +95,7 @@ function ChartPanel(props: Props) {
 
     return (
       <CSSTransition key={key} timeout={{ enter: 500, exit: 500 }} classNames="example" nodeRef={nodeRef}>
-        <Grid item xs={mapWidth(chartParameters.width, spacing)} ref={nodeRef}>
+        <Grid size={mapWidth(chartParameters.width, spacing)} ref={nodeRef}>
           <ChartWithTreeNode tree={props.tree} parameters={chartParameters} />
         </Grid>
       </CSSTransition>


### PR DESCRIPTION
## Problem

Since the MUI v7 upgrade (#940), `Grid` is the former `Grid2` and silently ignores the legacy `item`/`xs` props. The chart cards in the bottom chart panel therefore collapse to their intrinsic width: the chart svg falls back to the visx default of 300x150, and the time axis gets clipped.

| | card width (1024px window, 1 chart) |
|---|---|
| before | ~316px (intrinsic) |
| after | 598px = full panel width, matching v0.4.0-beta.7 |

## Fix

Use the `size` prop of the new Grid API. One line; the `12/6/4`-column logic in `mapWidth`/`spacingForChartCount` applies again.

## Verification

Measured via DevTools against a live broker: with one chart the card spans the full panel width, with two charts each card takes 50%, same as the released build. `yarn test:app` unchanged (103 passing, 4 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)