### PR TITLE
fix(app): inject emotion styles before legacy JSS styles

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { connect, Provider } from 'react-redux'
-import { ThemeProvider } from '@mui/material/styles'
+import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
 import { ThemeProvider as LegacyThemeProvider } from '@mui/styles'
 import App from './components/App'
 import Demo from './components/Demo'
@@ -15,12 +15,16 @@ import './autoConnectHandler' // Initialize auto-connect handling
 function ApplicationRenderer(props: { theme: 'light' | 'dark' }) {
   const theme = props.theme === 'light' ? themes.lightTheme : themes.darkTheme
   return (
-    <ThemeProvider theme={theme}>
-      <LegacyThemeProvider theme={theme}>
-        <App />
-        <Demo />
-      </LegacyThemeProvider>
-    </ThemeProvider>
+    // injectFirst puts emotion's styles before the JSS (@mui/styles) ones, so
+    // legacy withStyles/makeStyles rules keep overriding component defaults.
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <LegacyThemeProvider theme={theme}>
+          <App />
+          <Demo />
+        </LegacyThemeProvider>
+      </ThemeProvider>
+    </StyledEngineProvider>
   )
 }
 


### PR DESCRIPTION
## Problem

Emotion (MUI v5+) appends its stylesheets to `<head>` after the JSS stylesheets generated by the legacy `@mui/styles` `withStyles`/`makeStyles`. With equal selector specificity the emotion rules win, so every legacy JSS override in the app silently stops applying.

Visible symptoms include:
- the gap between the "MQTT Connection" dialog title and the connection URL disappears (`marginLeft` from `withStyles` is ignored),
- sidebar tab labels render in the wrong letter case,
- assorted small margins/paddings across the app fall back to component defaults.

## Fix

Wrap the app in `StyledEngineProvider injectFirst`, the interop setup MUI documents for codebases that still use `@mui/styles`. Emotion styles then land first in `<head>` and the JSS overrides win again, restoring the cascade the components were written against.

## Verification

Checked computed styles via DevTools before/after (e.g. the dialog URL `marginLeft: 32px` returns). `yarn test:app` unchanged (103 passing, 4 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)